### PR TITLE
SlackレガシーボットからSlack Appへの移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,18 @@ Button to report attendance to slack
 - Change parameters in `config.js` as described in the comments.
   - *Highly Recommend* : First, test on your personal test channel. 
 
-Details
+## Slack App Setup
 
-- Get `Bot API Token` from Slack.
-  - Open https://slack.com/apps/A0F7YS25R-bots
-  - push "Add to Slack" button
-  - copy `API Token`
+1. Go to [Slack API](https://api.slack.com/apps) and click "Create New App"
+2. Choose "From scratch" and set up app name and workspace
+3. In the "OAuth & Permissions" section, add the following scopes:
+   - `chat:write`
+   - `chat:write.public`
+4. Click "Install to Workspace" to install the app
+5. Copy the displayed "Bot User OAuth Token" (starting with `xoxb-`)
+6. Set this token in your `config.js` file in the `target_list`
+
+## Getting Thread IDs
 
 - Get thread_ts from message.
   - <img src="images/thread_ts_1.png" width="300">

--- a/config.js.dist
+++ b/config.js.dist
@@ -1,11 +1,10 @@
-let icon_url = 'https://example.com/user_icon.png';
-
-let user_name = 'kintai user name';
+// このファイルをconfig.jsとしてコピーして使用してください
+// Slack Appの設定に合わせて情報を更新してください
 
 // let default_custom_message = 'まで離席します';
 
 let target_list = [
-// channel,    thread_ts,           API Token
+// channel,    thread_ts,           Bot User OAuth Token
   ['#kintai1', '1234567890.012300', 'xoxb-111111111111-11111111111111-aaaaaaaaaaaaaaaaaaaaaaaa'],
   ['#kintai2', '1234567890.012300', 'xoxb-222222222222-22222222222222-bbbbbbbbbbbbbbbbbbbbbbbb'],
 ];

--- a/index.html
+++ b/index.html
@@ -174,8 +174,6 @@
                 let data = {
                     token: param_token,
                     channel: param_channel,
-                    username: user_name,
-                    icon_url: icon_url,
                     text: message,
                     reply_broadcast: reply_broadcast,
                     thread_ts: param_thread_ts,
@@ -183,7 +181,7 @@
 
                 // console.log(data)
                 $.ajax({
-                    type: 'GET',
+                    type: 'POST',
                     url: url,
                     data: data,
                 }).then(


### PR DESCRIPTION
## 概要
Slackレガシーカスタムボット廃止に伴い、Slack Appを使った処理に変更します。
https://slack.com/intl/ja-jp/help/articles/4426294050451

## 変更点
- レガシーSlack botからSlack Appへの移行
- READMEにSlack App設定手順の追加
  - Slack APIサイトでのアプリ作成方法
  - 必要なスコープ（chat:write, chat:write.public）の設定
  - Bot User OAuth Tokenの取得と設定方法
- config.js.distの更新
  - user_name, icon_urlを削除